### PR TITLE
Uses py3 collections.UserDict if possible

### DIFF
--- a/datatableview/utils.py
+++ b/datatableview/utils.py
@@ -1,4 +1,7 @@
-from UserDict import UserDict
+try:
+    from collections import UserDict
+except ImportError:
+    from UserDict import UserDict
 
 from django.utils.encoding import StrAndUnicode
 from django.template.loader import render_to_string


### PR DESCRIPTION
Uses Python 3.x `collections.UserDict` in place of Python 2.x `UserDict.UserDict` if possible.
