### PR TITLE
Fixes Python 3.3 reduce

### DIFF
--- a/datatableview/views.py
+++ b/datatableview/views.py
@@ -1,3 +1,7 @@
+try:
+   from functools import reduce
+except ImportError:
+   pass
 import json
 import re
 import operator


### PR DESCRIPTION
The built in `reduce` has been moved to `functools.reduce` in Python 3.3
