### PR TITLE
Adds Python3 support

### DIFF
--- a/datatableview/utils.py
+++ b/datatableview/utils.py
@@ -1,3 +1,8 @@
+try:
+    from functools import reduce
+except ImportError:
+    pass
+
 from collections import namedtuple
 
 try:
@@ -418,7 +423,7 @@ def filter_real_fields(model, fields, key=None):
 
     """
 
-    field_hints = zip(map(key, fields), fields)
+    field_hints = tuple(zip(map(key, fields), fields))
     field_map = dict(field_hints)
     field_list = set(field_map.keys())
     concrete_names = set(model._meta.get_all_field_names())


### PR DESCRIPTION
These changes get Python 3 working, but have not been tested with earlier Python versions.. Python 3 drops the `unicode()` medthod, and I susupect my fixes (changing `unicode()` to `str()`) will raise some errors in Python 2.

Along with these Python 3 specific fixes, The internal datatable `options` object (subclassed from Dict) was accessed like it had attributes( for instance, `options` supported calling `options.search` as an alias to `options['search']`) This behavior was removed, and all lookups are now called with the key index.
