### PR TITLE
DataTables Results string

### DIFF
--- a/datatableview/static/js/datatableview.js
+++ b/datatableview/static/js/datatableview.js
@@ -103,7 +103,7 @@ var datatableview = {
                 "aoColumns": column_options,
                 "sAjaxSource": datatable.attr('data-source-url'),
                 "fnInfoCallback": function(oSettings, iStart, iEnd, iMax, iTotal, sPre){
-                    $("#" + datatable.attr('data-result-counter-id')).html(iTotal);
+                    $("#" + datatable.attr('data-result-counter-id')).html(parseInt(iTotal).toLocaleString());
                     var infoString = "Showing "+iStart +" to "+ iEnd+" of "+iTotal+" entries";
                     if (iMax != iTotal) {
                         infoString +=  " (filtered from "+iMax+" total entries)";


### PR DESCRIPTION
The results string `Showing 11 to 20 of 219 entries` does not always get rendered in browsers like Chrome and Safari. 

You can see the affect on most pages with datatables. the numbers will not update, then if you highlight over the strings, it will magically update. 

Emptying the div before applying the text to it seems to convince chrome and safari to update the text. 

Big ass TODO requested by @rh0dium :tongue: 
