### PR TITLE
Django 1.7 support

### DIFF
--- a/datatableview/utils.py
+++ b/datatableview/utils.py
@@ -10,7 +10,16 @@ except ImportError:
 
 from django.db.models.fields import FieldDoesNotExist
 from django.template.loader import render_to_string
-from django.utils.encoding import StrAndUnicode
+
+try:
+    from django.utils.encoding import StrAndUnicode
+except ImportError:
+    from django.utils.encoding import python_2_unicode_compatible
+    @python_2_unicode_compatible
+    class StrAndUnicode:
+        def __str__(self):
+            return self.code
+
 from django.forms.util import flatatt
 
 import six


### PR DESCRIPTION
Django 1.7 removes StrAndUnicode from django.utils.encoding, as specified here:
https://docs.djangoproject.com/en/1.6/releases/1.5/#django-utils-encoding-strandunicode

So, I did what it said, and now it goes again, on my machine with my Django project :)
