### PR TITLE
remove unnecessary double counting queryset

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.md
 include requirements.txt
-recursive-include datatableview static/*
-recursive-include datatableview templates/*
+recursive-include datatableview/static *
+recursive-include datatableview/templates *

--- a/datatableview/views.py
+++ b/datatableview/views.py
@@ -136,8 +136,10 @@ class DatatableMixin(MultipleObjectMixin):
                         field_queries = []  # Queries generated to search this database field for the search term
 
                         field = resolve_orm_path(self.model, component_name)
-
-                        if isinstance(field, (models.CharField, models.TextField, models.FileField)):
+                        textual_fields = (models.CharField, models.TextField, models.FileField)
+                        if hasattr(models, 'GenericIPAddressField'):
+                            textual_fields += (getattr(models, 'GenericIPAddressField'),)
+                        if isinstance(field, textual_fields):
                             field_queries = [{component_name + '__icontains': term}]
                         elif isinstance(field, models.DateField):
                             try:

--- a/datatableview/views.py
+++ b/datatableview/views.py
@@ -201,7 +201,7 @@ class DatatableMixin(MultipleObjectMixin):
         if not sort_fields and not searches:
             # We can shortcut and speed up the process if all operations are database-backed.
             object_list = queryset
-            object_list._dtv_unpaged_total = queryset.count()
+            object_list._dtv_unpaged_total = queryset.count() if options['search'] else total_initial_record_count
         else:
             object_list = ObjectListResult(queryset)
 


### PR DESCRIPTION
When search field is left blank the original version counts twice almost the same queryset - it can differ only by sorting, which is irrelevant when getting count. This patch removes this inefficiency.