### PR TITLE
Fixes pivotal-energy-solutions/django-datatable-view#76

### DIFF
--- a/datatableview/utils.py
+++ b/datatableview/utils.py
@@ -53,7 +53,7 @@ OPTION_NAME_MAP = {
 FIELD_TYPES = {
     'text': [models.CharField, models.TextField, models.FileField],
     'date': [models.DateField],
-    'boolean': [models.BooleanField],
+    'boolean': [models.BooleanField, models.NullBooleanField],
     'integer': [models.IntegerField, models.AutoField],
     'float': [models.FloatField, models.DecimalField],
 


### PR DESCRIPTION
Added models.NullBooleanField to the FIELD_TYPES