### PR TITLE
Allow searching on field choices display names

### DIFF
--- a/datatableview/helpers.py
+++ b/datatableview/helpers.py
@@ -89,6 +89,17 @@ def link_to_model(instance, text=None, *args, **kwargs):
 
 
 @keyed_helper
+def field_display(instance, *args, **kwargs):
+    """
+    Returns the display name of a field
+    """
+    field_name = kwargs.get('field_data')[1]
+    field_display_method_name = 'get_' + field_name + '_display'
+    method = getattr(instance, field_display_method_name)
+    return u"{}".format(method())
+
+
+@keyed_helper
 def make_boolean_checkmark(value, true_value="&#10004;", false_value="&#10008;", *args, **kwargs):
     value = kwargs.get('default_value', value)
     if value:

--- a/datatableview/tests/example_project/example_project/example_app/fixtures/initial_data.json
+++ b/datatableview/tests/example_project/example_project/example_app/fixtures/initial_data.json
@@ -37,7 +37,7 @@
         "mod_date": "2013-02-02",
         "n_comments": 0,
         "n_pingbacks": 5,
-        "rating": 0,
+        "rating": 1,
         "authors": [2]
     }},
     { "model": "example_app.Entry", "pk": 3, "fields": {
@@ -48,7 +48,7 @@
         "mod_date": "2013-01-02",
         "n_comments": 0,
         "n_pingbacks": 0,
-        "rating": 0,
+        "rating": 3,
         "authors": [1, 2]
     }},
     { "model": "example_app.Entry", "pk": 4, "fields": {
@@ -59,7 +59,7 @@
         "mod_date": "2013-01-02",
         "n_comments": 273,
         "n_pingbacks": 1017,
-        "rating": 0,
+        "rating": 2,
         "authors": [1, 2]
     }},
     { "model": "example_app.Entry", "pk": 5, "fields": {
@@ -70,7 +70,7 @@
         "mod_date": "2013-01-02",
         "n_comments": 0,
         "n_pingbacks": 0,
-        "rating": 0,
+        "rating": 2,
         "authors": [1, 2]
     }},
     { "model": "example_app.Entry", "pk": 6, "fields": {
@@ -81,7 +81,7 @@
         "mod_date": "2013-01-02",
         "n_comments": 0,
         "n_pingbacks": 0,
-        "rating": 0,
+        "rating": 5,
         "authors": [1, 2]
     }}
 ]

--- a/datatableview/tests/example_project/example_project/example_app/models.py
+++ b/datatableview/tests/example_project/example_project/example_app/models.py
@@ -23,6 +23,16 @@ class Author(models.Model):
 
 
 class Entry(models.Model):
+
+    _rating_choices = (
+        (0, 'Ridiculous'),
+        (1, 'Awful'),
+        (2, 'Bad'),
+        (3, 'Average'),
+        (4, 'Good'),
+        (5, 'Excellent'),
+    )
+
     blog = models.ForeignKey(Blog)
     headline = models.CharField(max_length=255)
     body_text = models.TextField()
@@ -31,7 +41,7 @@ class Entry(models.Model):
     authors = models.ManyToManyField(Author)
     n_comments = models.IntegerField()
     n_pingbacks = models.IntegerField()
-    rating = models.IntegerField()
+    rating = models.IntegerField(choices=_rating_choices)
 
     def __unicode__(self):
         return self.headline

--- a/datatableview/tests/example_project/example_project/example_app/views.py
+++ b/datatableview/tests/example_project/example_project/example_app/views.py
@@ -169,7 +169,7 @@ class PrettyNamesDatatableView(DemoMixin, DatatableView):
             'headline',
             ("Publication date", 'pub_date'),
             'n_comments',
-            'rating',
+            ('rating', 'rating', helpers.field_display),
         ]
     }
 

--- a/datatableview/views.py
+++ b/datatableview/views.py
@@ -136,7 +136,22 @@ class DatatableMixin(MultipleObjectMixin):
                         field_queries = []  # Queries generated to search this database field for the search term
 
                         field = resolve_orm_path(self.model, component_name)
-                        if isinstance(field, tuple(FIELD_TYPES['text'])):
+                        if field.choices:
+                            # Query the database for the database value rather than display value
+                            choices = field.get_flatchoices()
+                            length = len(choices)
+                            database_values = []
+                            display_values = []
+
+                            for choice in choices:
+                                database_values.append(choice[0])
+                                display_values.append(choice[1].lower())
+
+                            for i in range(length):
+                                if term.lower() in display_values[i]:
+                                    field_queries = [{component_name + '__iexact': database_values[i]}]
+
+                        elif isinstance(field, tuple(FIELD_TYPES['text'])):
                             field_queries = [{component_name + '__icontains': term}]
                         elif isinstance(field, tuple(FIELD_TYPES['date'])):
                             try:


### PR DESCRIPTION
If a field has a set of choices this PR makes it possible to search using the display name rather than the stored database value.