### PR TITLE
Fix OverflowErrors related to searching and dates

### DIFF
--- a/datatableview/views.py
+++ b/datatableview/views.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import re
 import operator
@@ -174,7 +175,7 @@ class DatatableMixin(MultipleObjectMixin):
                             except ValueError:
                                 pass
                             else:
-                                if 0 < numerical_value < 3000:
+                                if datetime.MINYEAR < numerical_value < datetime.MAXYEAR - 1:
                                     field_queries.append({component_name + '__year': numerical_value})
                                 if 0 < numerical_value <= 12:
                                     field_queries.append({component_name + '__month': numerical_value})

--- a/datatableview/views.py
+++ b/datatableview/views.py
@@ -162,6 +162,9 @@ class DatatableMixin(MultipleObjectMixin):
                             except TypeError:
                                 # Failed conversions can lead to the parser adding ints to None.
                                 pass
+                            except OverflowError:
+                                # Catches OverflowError: signed integer is greater than maximum
+                                pass
                             else:
                                 field_queries.append({component_name: date_obj})
 


### PR DESCRIPTION
* `dateutil.parser.parse` raises an `OverflowError` if a too big integer is typed into the search
* Year filtering in the more granular date field lookup might also raise an `OverflowError` when Django is trying to make the datetime object timezone aware. Year filtering now supports years almost up to the `datetime.MAXYEAR`. It has small offset so that so that we don't hit that nasty `OverflowError`.