### PR TITLE
Add ability to define field specific queries

### DIFF
--- a/datatableview/__init__.py
+++ b/datatableview/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 __name__ = 'datatableview'
 __author__ = 'Tim Valenta'
-__version_info__ = (0, 8, 1)
+__version_info__ = (0, 8, 1, 2)
 __version__ = '.'.join(map(str, __version_info__))
 __date__ = '2013/11/14 2:00:00 PM'
 __credits__ = ['Tim Valenta', 'Steven Klass']

--- a/datatableview/__init__.py
+++ b/datatableview/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 __name__ = 'datatableview'
 __author__ = 'Tim Valenta'
-__version_info__ = (0, 8, 1, 2)
+__version_info__ = (0, 8, 1, 3)
 __version__ = '.'.join(map(str, __version_info__))
 __date__ = '2013/11/14 2:00:00 PM'
 __credits__ = ['Tim Valenta', 'Steven Klass']

--- a/datatableview/views.py
+++ b/datatableview/views.py
@@ -96,6 +96,106 @@ class DatatableMixin(MultipleObjectMixin):
             self._datatable_options = options
         return self._datatable_options
 
+    def _buildSearchQueries( self, db_fields, search_query, is_regex ):
+        queries = []
+
+        if is_regex:
+            field_queries = []
+            for column in db_fields:
+                column = get_field_definition( column )
+                for component_name in column.fields + column.search_fields:
+                    field = resolve_orm_path( self.model, component_name )
+                    if isinstance( field, tuple( FIELD_TYPES['text'] ) ):
+                        field_queries.append( Q( **{ component_name + u'__iregex' : search_query } ) )
+            queries.append( reduce( operator.or_, field_queries ) )
+        else:
+            search_terms = map( lambda q: q.strip( "'\" " ), smart_split( search_query ) )
+            for term in search_terms:
+                term_queries = [ ]  # Queries generated to search all fields for this term
+                # Every concrete database lookup string in 'columns' is followed to its trailing field descriptor.  For example, "subdivision__name" terminates in a CharField.  The field type determines how it is probed for search.
+                for column in db_fields:
+                    column = get_field_definition( column )
+                    for component_name in column.fields + column.search_fields:
+                        field_queries = [ ]  # Queries generated to search this database field for the search term
+                        field = resolve_orm_path( self.model, component_name )
+                        if field.choices:
+                            # Query the database for the database value rather than display value
+                            choices = field.get_flatchoices()
+                            length = len(choices)
+                            database_values = []
+                            display_values = []
+
+                            for choice in choices:
+                                database_values.append(choice[0])
+                                display_values.append(choice[1].lower())
+
+                            for i in range(length):
+                                if term.lower() in display_values[i]:
+                                    field_queries = [{component_name + '__iexact': database_values[i]}]
+                        elif isinstance( field, tuple( FIELD_TYPES[ 'text' ] ) ):
+                            field_queries = [ { component_name + '__icontains': term } ]
+                        elif isinstance( field, tuple( FIELD_TYPES[ 'date' ] ) ):
+                            try:
+                                date_obj = dateutil.parser.parse( term )
+                            except ValueError:
+                                # This exception is theoretical, but it doesn't seem to raise.
+                                pass
+                            except TypeError:
+                                # Failed conversions can lead to the parser adding ints to None.
+                                pass
+                            except OverflowError:
+                                # Catches OverflowError: signed integer is greater than maximum
+                                pass
+                            else:
+                                field_queries.append( { component_name: date_obj } )
+
+                            # Add queries for more granular date field lookups
+                            try:
+                                numerical_value = int( term )
+                            except ValueError:
+                                pass
+                            else:
+                                if datetime.MINYEAR < numerical_value < datetime.MAXYEAR - 1:
+                                    field_queries.append({component_name + '__year': numerical_value})
+                                if 0 < numerical_value <= 12:
+                                    field_queries.append( { component_name + '__month': numerical_value } )
+                                if 0 < numerical_value <= 31:
+                                    field_queries.append( { component_name + '__day': numerical_value } )
+                        elif isinstance( field, tuple( FIELD_TYPES[ 'boolean' ] ) ):
+                            if term.lower( ) in ('true', 'yes'):
+                                term = True
+                            elif term.lower( ) in ('false', 'no'):
+                                term = False
+                            else:
+                                continue
+
+                            field_queries = [ { component_name: term } ]
+                        elif isinstance( field, tuple( FIELD_TYPES[ 'integer' ] ) ):
+                            try:
+                                field_queries = [ { component_name: int( term ) } ]
+                            except ValueError:
+                                pass
+                        elif isinstance( field, tuple( FIELD_TYPES[ 'float' ] ) ):
+                            try:
+                                field_queries = [ { component_name: float( term ) } ]
+                            except ValueError:
+                                pass
+                        elif isinstance( field, tuple( FIELD_TYPES[ 'ignored' ] ) ):
+                            pass
+                        else:
+                            raise ValueError(
+                                "Unhandled field type for %s (%r) in search." % (component_name, type( field )) )
+
+                        # print field_queries
+
+                        # Append each field inspection for this term
+                        term_queries.extend( map( lambda q: Q( **q ), field_queries ) )
+                # Append the logical OR of all field inspections for this term
+                if len( term_queries ):
+                    queries.append( reduce( operator.or_, term_queries ) )
+
+        return queries
+
     def apply_queryset_options(self, queryset):
         """
         Interprets the datatable options.
@@ -120,101 +220,44 @@ class DatatableMixin(MultipleObjectMixin):
             db_fields, sort_fields = split_real_fields(self.model, options['ordering'])
             queryset = queryset.order_by(*db_fields)
 
-        if options['search']:
-            db_fields, searches = filter_real_fields(self.model, options['columns'],
+        if options['search'] or [ x for x in options['column_searches' ] if x ]:
+            org_db_fields, searches = filter_real_fields(self.model, options['columns'],
                                                      key=get_first_orm_bit)
-            db_fields.extend(options['search_fields'])
+            db_fields = org_db_fields + options['search_fields']
 
-            queries = []  # Queries generated to search all fields for all terms
-            search_terms = map(lambda q: q.strip("'\" "), smart_split(options['search']))
+            all_queries = []
+            global_search = options['search']
 
-            for term in search_terms:
-                term_queries = []  # Queries generated to search all fields for this term
-                # Every concrete database lookup string in 'columns' is followed to its trailing field descriptor.  For example, "subdivision__name" terminates in a CharField.  The field type determines how it is probed for search.
-                for column in db_fields:
-                    column = get_field_definition(column)
-                    for component_name in column.fields:
-                        field_queries = []  # Queries generated to search this database field for the search term
+            if global_search:
+                if global_search.startswith( u'!' ):
+                    is_exclude = True
+                    global_search = global_search[1:]
+                else:
+                    is_exclude = False
 
-                        field = resolve_orm_path(self.model, component_name)
-                        if field.choices:
-                            # Query the database for the database value rather than display value
-                            choices = field.get_flatchoices()
-                            length = len(choices)
-                            database_values = []
-                            display_values = []
+                queries = [ ( x, is_exclude ) for x in self._buildSearchQueries( db_fields, global_search, options['is_regex'] ) ]
+                all_queries += queries
 
-                            for choice in choices:
-                                database_values.append(choice[0])
-                                display_values.append(choice[1].lower())
+            for db_field, col_search in zip( org_db_fields, options['column_searches'] ):
+                if not col_search:
+                    continue
 
-                            for i in range(length):
-                                if term.lower() in display_values[i]:
-                                    field_queries = [{component_name + '__iexact': database_values[i]}]
+                if col_search.startswith( u'!' ):
+                    is_exclude = True
+                    col_search = col_search[1:]
+                else:
+                    is_exclude = False
 
-                        elif isinstance(field, tuple(FIELD_TYPES['text'])):
-                            field_queries = [{component_name + '__icontains': term}]
-                        elif isinstance(field, tuple(FIELD_TYPES['date'])):
-                            try:
-                                date_obj = dateutil.parser.parse(term)
-                            except ValueError:
-                                # This exception is theoretical, but it doesn't seem to raise.
-                                pass
-                            except TypeError:
-                                # Failed conversions can lead to the parser adding ints to None.
-                                pass
-                            except OverflowError:
-                                # Catches OverflowError: signed integer is greater than maximum
-                                pass
-                            else:
-                                field_queries.append({component_name: date_obj})
+                queries = [ ( x, is_exclude ) for x in self._buildSearchQueries( [ db_field ], col_search, options['is_regex'] ) ]
+                all_queries += queries
 
-                            # Add queries for more granular date field lookups
-                            try:
-                                numerical_value = int(term)
-                            except ValueError:
-                                pass
-                            else:
-                                if datetime.MINYEAR < numerical_value < datetime.MAXYEAR - 1:
-                                    field_queries.append({component_name + '__year': numerical_value})
-                                if 0 < numerical_value <= 12:
-                                    field_queries.append({component_name + '__month': numerical_value})
-                                if 0 < numerical_value <= 31:
-                                    field_queries.append({component_name + '__day': numerical_value})
-                        elif isinstance(field, tuple(FIELD_TYPES['boolean'])):
-                            if term.lower() in ('true', 'yes'):
-                                term = True
-                            elif term.lower() in ('false', 'no'):
-                                term = False
-                            else:
-                                continue
+            include_queries = [ q for ( q, is_exclude ) in all_queries if not is_exclude ]
+            exclude_queries = [ q for ( q, is_exclude ) in all_queries if is_exclude ]
 
-                            field_queries = [{component_name: term}]
-                        elif isinstance(field, tuple(FIELD_TYPES['integer'])):
-                            try:
-                                field_queries = [{component_name: int(term)}]
-                            except ValueError:
-                                pass
-                        elif isinstance(field, tuple(FIELD_TYPES['float'])):
-                            try:
-                                field_queries = [{component_name: float(term)}]
-                            except ValueError:
-                                pass
-                        elif isinstance(field, tuple(FIELD_TYPES['ignored'])):
-                            pass
-                        else:
-                            raise ValueError("Unhandled field type for %s (%r) in search." % (component_name, type(field)))
-
-                        # print field_queries
-
-                        # Append each field inspection for this term
-                        term_queries.extend(map(lambda q: Q(**q), field_queries))
-                # Append the logical OR of all field inspections for this term
-                if len(term_queries):
-                    queries.append(reduce(operator.or_, term_queries))
-            # Apply the logical AND of all term inspections
-            if len(queries):
-                queryset = queryset.filter(reduce(operator.and_, queries))
+            if include_queries:
+                queryset = queryset.filter( reduce( operator.and_, include_queries ) )
+            if exclude_queries:
+                queryset = queryset.exclude( reduce( operator.or_, exclude_queries ) )
 
         # TODO: Remove "and not searches" from this conditional, since manual searches won't be done
         if not sort_fields and not searches:

--- a/datatableview/views.py
+++ b/datatableview/views.py
@@ -122,7 +122,12 @@ class DatatableMixin(MultipleObjectMixin):
                     for component_name in column.fields + column.search_fields:
                         field_queries = [ ]  # Queries generated to search this database field for the search term
                         field = resolve_orm_path( self.get_model(), component_name )
-                        if field.choices:
+
+                        field_method_name = 'search_' + field.name
+                        if hasattr(self, field_method_name):
+                            # Call field specific method to get the field queries
+                            field_queries.append(getattr(self, field_method_name)(component_name, field, term))
+                        elif field.choices:
                             # Query the database for the database value rather than display value
                             choices = field.get_flatchoices()
                             length = len(choices)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 setup(name='django-datatable-view',
-      version='0.8.1',
+      version='0.8.1.2',
       description='This package is used in conjunction with the jQuery plugin '
                   '(http://http://datatables.net/), and supports state-saving detection'
                   ' with (http://datatables.net/plug-ins/api).  The package consists of '

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup, find_packages
 
 setup(name='django-datatable-view',
-      version='0.8.1.2',
+      version='0.8.1.3',
       description='This package is used in conjunction with the jQuery plugin '
                   '(http://http://datatables.net/), and supports state-saving detection'
                   ' with (http://datatables.net/plug-ins/api).  The package consists of '


### PR DESCRIPTION
Previously field specific queries were made in a really opinionated way. It was hard to alter the query made against the database.

Now there is a way to define a custom query for each field by defining `search_field_name` method.

For example, by default `DecimalFields` field query is set like this:
```field_queries = [{component_name: float(term)}]```

With the new feature you can customize that like this:

```
def search_my_field_name(self, field, query_term):
        # Return dict containing query string as a key and query_term as a value.
        return {field.name + '__icontains': query_term}
```