### PR TITLE
Enable field specific query customization

### DIFF
--- a/datatableview/views.py
+++ b/datatableview/views.py
@@ -137,7 +137,11 @@ class DatatableMixin(MultipleObjectMixin):
                         field_queries = []  # Queries generated to search this database field for the search term
 
                         field = resolve_orm_path(self.model, component_name)
-                        if field.choices:
+                        field_method_name = 'search_' + field.name
+                        if hasattr(self, field_method_name):
+                            # Call field specific method to get the field query
+                            field_queries.append(getattr(self, field_method_name)(field, term, component_name))
+                        elif field.choices:
                             # Query the database for the database value rather than display value
                             choices = field.get_flatchoices()
                             length = len(choices)


### PR DESCRIPTION
Previously field specific queries were made in a really opinionated
way. It was hard to alter the query made against the database.

Now there is a way to define a custom query for each field by defining
search_field_name method.

For example, by default DecimalFields field query is set like this:
`field_queries = [{component_name: float(term)}]`

With the new feature you can customize that like this:

```
def search_my_field_name(self, field, query_term, component_name):
    # Return dict containing query string as a key and query_term as a value.
    return {field.name + '__icontains': query_term}
```