### PR TITLE
Add override hooks for subclasses

### DIFF
--- a/datatableview/views.py
+++ b/datatableview/views.py
@@ -23,9 +23,9 @@ import six
 import dateutil.parser
 
 from .forms import XEditableUpdateForm
-from .utils import (FIELD_TYPES, ObjectListResult, DatatableOptions, split_real_fields,
-        filter_real_fields, get_datatable_structure, resolve_orm_path, get_first_orm_bit,
-        get_field_definition)
+from .utils import (FIELD_TYPES, ObjectListResult, DatatableOptions, DatatableStructure,
+                    split_real_fields, filter_real_fields, resolve_orm_path, get_first_orm_bit,
+                    get_field_definition)
 
 log = logging.getLogger(__name__)
 
@@ -48,6 +48,8 @@ class DatatableMixin(MultipleObjectMixin):
 
     datatable_options = None
     datatable_context_name = 'datatable'
+    datatable_options_class = DatatableOptions
+    datatable_structure_class = DatatableStructure
 
     def get(self, request, *args, **kwargs):
         """
@@ -60,9 +62,22 @@ class DatatableMixin(MultipleObjectMixin):
             return self.get_ajax(request, *args, **kwargs)
         return super(DatatableMixin, self).get(request, *args, **kwargs)
 
+    def get_model(self):
+        if not self.model:
+            self.model = self.get_queryset().model
+        return self.model
+
     def get_object_list(self):
         """ Gets the core queryset, but applies the datatable options to it. """
         return self.apply_queryset_options(self.get_queryset())
+
+    def get_ajax_url(self):
+        return self.request.path
+
+    def get_datatable_structure(self):
+        options = self._get_datatable_options()
+        model = self.get_model()
+        return self.datatable_structure_class(self.get_ajax_url(), options, model=model)
 
     def get_datatable_options(self):
         """
@@ -82,16 +97,15 @@ class DatatableMixin(MultipleObjectMixin):
         """
 
         if not hasattr(self, '_datatable_options'):
-            if self.model is None:
-                self.model = self.get_queryset().model
+            model = self.get_model()
 
             options = self.get_datatable_options()
             if options:
                 # Options are defined, but probably in a raw dict format
-                options = DatatableOptions(self.model, self.request.GET, **dict(options))
+                options = self.datatable_options_class(model, self.request.GET, **dict(options))
             else:
                 # No options defined on the view
-                options = DatatableOptions(self.model, self.request.GET)
+                options = self.datatable_options_class(model, self.request.GET)
 
             self._datatable_options = options
         return self._datatable_options
@@ -117,11 +131,11 @@ class DatatableMixin(MultipleObjectMixin):
         total_initial_record_count = queryset.count()
 
         if options['ordering']:
-            db_fields, sort_fields = split_real_fields(self.model, options['ordering'])
+            db_fields, sort_fields = split_real_fields(self.get_model(), options['ordering'])
             queryset = queryset.order_by(*db_fields)
 
         if options['search']:
-            db_fields, searches = filter_real_fields(self.model, options['columns'],
+            db_fields, searches = filter_real_fields(self.get_model(), options['columns'],
                                                      key=get_first_orm_bit)
             db_fields.extend(options['search_fields'])
 
@@ -136,7 +150,7 @@ class DatatableMixin(MultipleObjectMixin):
                     for component_name in column.fields:
                         field_queries = []  # Queries generated to search this database field for the search term
 
-                        field = resolve_orm_path(self.model, component_name)
+                        field = resolve_orm_path(self.get_model(), component_name)
                         if field.choices:
                             # Query the database for the database value rather than display value
                             choices = field.get_flatchoices()
@@ -301,9 +315,7 @@ class DatatableMixin(MultipleObjectMixin):
         Returns the helper object that can be used in the template to render the datatable skeleton.
 
         """
-
-        options = self._get_datatable_options()
-        return get_datatable_structure(self.request.path, options, model=self.model)
+        return self.get_datatable_structure()
 
     def get_context_data(self, **kwargs):
         context = super(DatatableMixin, self).get_context_data(**kwargs)
@@ -559,10 +571,6 @@ class XEditableMixin(object):
     def get_ajax_xeditable_choices(self, request, *args, **kwargs):
         """ AJAX GET handler for xeditable queries asking for field choice lists. """
         field_name = request.GET[self.xeditable_fieldname_param]
-
-        if not self.model:
-            self.model = self.get_queryset().model
-
         # Sanitize the requested field name by limiting valid names to the datatable_options columns
         columns = self._get_datatable_options()['columns']
         for name in columns:
@@ -573,7 +581,7 @@ class XEditableMixin(object):
         else:
             return HttpResponseBadRequest()
 
-        field = self.model._meta.get_field_by_name(field_name)[0]
+        field = self.get_model()._meta.get_field_by_name(field_name)[0]
 
         choices = self.get_field_choices(field, field_name)
         return HttpResponse(json.dumps(choices))


### PR DESCRIPTION
These hooks make it easy for subclasses of the `DatatableView` to override previously hardcoded functionality.