### PR TITLE
Fix for Django 1.8 relationship field internals change

### DIFF
--- a/datatableview/utils.py
+++ b/datatableview/utils.py
@@ -126,14 +126,19 @@ def get_model_at_related_field(model, attr):
     except FieldDoesNotExist:
         raise
 
-    if not direct and hasattr(field, 'related_model'):  # Reverse relationship
-        model = field.related_model
-    elif hasattr(field, 'rel') and field.rel:  # Forward/m2m relationship
-        model = field.rel.to
-    else:
-        raise ValueError("{0}.{1} ({2}) is not a relationship field.".format(model.__name__, attr,
-                field.__class__.__name__))
-    return model
+    if not direct:
+        if hasattr(field, 'related_model'):  # Reverse relationship
+            # -- Django >=1.8 mode
+            return field.related_model
+        elif hasattr(field, "model"):
+            # -- Django <1.8 mode
+            return field.model
+
+    if hasattr(field, 'rel') and field.rel:  # Forward/m2m relationship
+        return field.rel.to
+
+    raise ValueError("{0}.{1} ({2}) is not a relationship field.".format(model.__name__, attr,
+            field.__class__.__name__))
 
 
 def get_first_orm_bit(field_definition):

--- a/datatableview/utils.py
+++ b/datatableview/utils.py
@@ -126,8 +126,8 @@ def get_model_at_related_field(model, attr):
     except FieldDoesNotExist:
         raise
 
-    if not direct and hasattr(field, 'model'):  # Reverse relationship
-        model = field.model
+    if not direct and hasattr(field, 'related_model'):  # Reverse relationship
+        model = field.related_model
     elif hasattr(field, 'rel') and field.rel:  # Forward/m2m relationship
         model = field.rel.to
     else:


### PR DESCRIPTION
The current utils.get_model_at_related_field is broken. 

- [x] Failing Unit Test(s) Created (* The failing test already existed)
- [x] Tests Pass (* The failing unittest passes, there are still 4, previously existing failures)
- [x] pyflakes run (* Nothing changed )
- [x] Travis Tests Pass:  Django 1.4, 1.5, 1.6, 1.7 and 1.8 fail, but not THIS test :smile: 

I've withdrawn my previous PR and replaced it with this one with works with  The bug was Django 1.8 specific - which I've confirmed using the soon to be made Travis CI PR.  There are a bunch of other test failures that started with Django 1.7 that I'll look into next-ish.