### PR TITLE
Adds options for custom controls

### DIFF
--- a/datatableview/views.py
+++ b/datatableview/views.py
@@ -225,6 +225,8 @@ class DatatableMixin(MultipleObjectMixin):
 
                         # Append each field inspection for this term
                         term_queries.extend(map(lambda q: Q(**q), field_queries))
+                # Apply custom field queries
+                term_queries.extend(map(lambda q: Q(**q), self.get_custom_field_queries(term)))
                 # Append the logical OR of all field inspections for this term
                 if len(term_queries):
                     queries.append(reduce(operator.or_, term_queries))
@@ -311,6 +313,9 @@ class DatatableMixin(MultipleObjectMixin):
 
         object_list._dtv_total_initial_record_count = total_initial_record_count
         return object_list
+        
+    def get_custom_field_queries(self, term):
+        return []
 
     def get_datatable_context_name(self):
         return self.datatable_context_name


### PR DESCRIPTION
Adds the ability to provide extra lookups in an imperative fashion.

With this little addition, you can provide extra controls for table columns that do not correspond to a field on the model, e.g. my model `Customer` has a property `identifier`, which is displayed in a table column, and I want to be able to filter by that column.

```python
class Customer(models.Model):
    [...]
    @property
    def identifier(self):
        return 'CUS-{}'.format(self.customer_number.pk)
```

With the change in this commit, I can construct my view with

```python
class CustomerListView(DatatableView):
    """
    Lists all customers
    """
    model = Customer
    [...]

    def get_custom_field_queries(self, term):
        fqs = super().get_custom_field_queries(term)

        if term.lower() in 'CUS-'.lower():
            fqs.append({'customer_number__isnull': False})
        match = re.match('cus-(\d+)', term.lower())
        if match:
            fqs.append({'customer_number__pk__istartswith': match.group(1)})
        return fqs
```

Now, when I search for `CUS-`, I find all customers with a customer number, and when I search for `CUS-1`, I find all customers whose numbers start with 1