### PR TITLE
Load flatatt from django.forms.utils (.util deprecated in Django 1.9)

### DIFF
--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -15,7 +15,10 @@ from django.db.models.fields import FieldDoesNotExist
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.encoding import smart_text
 from django.utils.safestring import mark_safe
-from django.forms.util import flatatt
+try:
+    from django.forms.utils import flatatt
+except ImportError:
+    from django.forms.util import flatatt
 from django.template.defaultfilters import slugify
 try:
     from django.utils.encoding import python_2_unicode_compatible


### PR DESCRIPTION
```
columns.py:18: RemovedInDjango19Warning: The django.forms.util module has been renamed. Use django.forms.utils instead.
  from django.forms.util import flatatt
```