### PR TITLE
Fix virtual sort when comparing various-length values

### DIFF
--- a/datatableview/datatables.py
+++ b/datatableview/datatables.py
@@ -511,14 +511,20 @@ class Datatable(six.with_metaclass(DatatableMetaclass)):
         if virtual:
             # Have to sort the whole queryset by hand!
             object_list = list(object_list)
-
+            
+            def flatten(value):
+                if isinstance(value, (list, tuple)):
+                    return flatten(value[0])
+                else:
+                    return value
+                
             for name in virtual[::-1]:  # stable sorting, top priority sort comes last
                 reverse = False
                 if name[0] in '+-':
                     reverse = (name[0] == '-')
                     name = name[1:]
                 column = self.columns[name]
-                object_list.sort(key=lambda o: column.value(o)[0], reverse=reverse)
+                object_list.sort(key=lambda o: flatten(column.value(o)), reverse=reverse)
 
         return object_list
 


### PR DESCRIPTION
### Steps to reproduce

1. have a `Datatable` with
   * a single-source column eg. `foo = TextColumn("foo", sources=['foo'])`
   * a dual-source column eg. `bar = TextColumn("bar", sources=['bar', 'baz'])`
1. in the corresponding `DatatableView`, sort by Foo then **further sort** (shift+click) by Bar

### The trackback
```python-traceback
  File "datatableview/datatables.py", line 443, in populate_records
    objects = self.sort(objects)
  File "datatableview/datatables.py", line 521, in sort
    object_list.sort(key=lambda o: column.value(o)[0], reverse=reverse)
TypeError: unorderable types: list() < str()
```
Indeed, for *foo*, `column.value(o)` is `("foo-value", "Foo value")`; whereas for *bar*, `column.value(o)` is `(["bar-value", "baz-value"], "Bar Baz Value")` hence Python tries to compare the string `"foo-value"` with the list `["bar-value", "baz-value"]`.

### The fix
I recursively flatten the value so that it always return a literal we can compare to, instead of a list that can be nested. I am not sure this is the best approach but at least it works (debugged & tested in my project). Please tell me if I missed something.