### PR TITLE
fix: search BooleanColumn by true or also and add search by boolean column label

### DIFF
--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -15,7 +15,10 @@ from django.db.models.fields import FieldDoesNotExist
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.encoding import smart_text
 from django.utils.safestring import mark_safe
-from django.forms.util import flatatt
+try:
+    from django.forms.util import flatatt
+except ImportError:
+    from django.forms.utils import flatatt
 from django.template.defaultfilters import slugify
 try:
     from django.utils.encoding import python_2_unicode_compatible

--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -326,7 +326,7 @@ class Column(six.with_metaclass(ColumnMetaclass)):
             lookup_types += ('search',)
         return lookup_types
 
-    def search(self, model, term):
+    def search(self, model, term, lookup_types=None):
         """
         Returns the ``Q`` object representing queries to make against this column for the given
         term.
@@ -356,7 +356,8 @@ class Column(six.with_metaclass(ColumnMetaclass)):
                             k = '%s__exact' % (sub_source,)
                             column_queries.append(Q(**{k: str(db_value)}))
 
-                lookup_types = handler.get_lookup_types()
+                if not lookup_types:
+                    lookup_types = handler.get_lookup_types()
                 for lookup_type in lookup_types:
                     coerced_term = handler.prep_search_value(term, lookup_type)
                     if coerced_term is None:

--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -292,8 +292,8 @@ class Column(six.with_metaclass(ColumnMetaclass)):
             in_bits = re.split(r',\s*', term)
             if len(in_bits) > 1:
                 multi_terms = in_bits
-            else:
-                term = None
+            # else:
+            #     term = None
 
         if lookup_type == "range":
             range_bits = re.split(r'\s*-\s*', term)
@@ -481,10 +481,11 @@ class BooleanColumn(Column):
 
     def prep_search_value(self, term, lookup_type):
         term = term.lower()
-        if term == 'true':
-            term = True
+        # this helps filter users with active status by typing active
+        if term == 'true' or term in self.label.lower():
+            return True
         elif term == 'false':
-            term = False
+            return False
         else:
             return None
         return super(BooleanColumn, self).prep_search_value(term, lookup_type)

--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -208,7 +208,9 @@ class Column(six.with_metaclass(ColumnMetaclass)):
         ``Column`` instances will have sources of their own and need to return a value per nested
         source.
         """
-        if isinstance(obj, Model):
+        if hasattr(source, "__call__"):
+            value = source(obj)
+        elif isinstance(obj, Model):
             value = reduce(get_attribute_value, [obj] + source.split('__'))
         elif isinstance(obj, dict):  # ValuesQuerySet item
             value = obj[source]
@@ -262,6 +264,8 @@ class Column(six.with_metaclass(ColumnMetaclass)):
     def resolve_source(self, model, source):
         # Try to fetch the leaf attribute.  If this fails, the attribute is not database-backed and
         # the search for the first non-database field should end.
+        if hasattr(source, "__call__"):
+            return None
         try:
             return resolve_orm_path(model, source)
         except FieldDoesNotExist:

--- a/datatableview/tests/example_project/example_project/example_app/templates/demos/col_reorder.html
+++ b/datatableview/tests/example_project/example_project/example_app/templates/demos/col_reorder.html
@@ -5,8 +5,8 @@
     <script src="{{ STATIC_URL }}syntaxhighlighter/shBrushJScript.js" type="text/javascript"></script>
 
     <!-- Resources for "ColReorder" demo -->
-    <link href="https://cdn.datatables.net/colreorder/1.1.0/css/colReorder.dataTables.min.css" rel="stylesheet"/>
-    <script src="https://cdn.datatables.net/colreorder/1.1.0/js/dataTables.colReorder.min.js"></script>
+    <link href="https://cdn.datatables.net/colreorder/1.3.2/css/colReorder.dataTables.min.css" rel="stylesheet"/>
+    <script src="https://cdn.datatables.net/colreorder/1.3.2/js/dataTables.colReorder.min.js"></script>
 
     <!-- Initialization for ColReorder tables -->
     <script type="text/javascript">

--- a/datatableview/tests/example_project/example_project/example_app/templates/example_base.html
+++ b/datatableview/tests/example_project/example_project/example_app/templates/example_base.html
@@ -6,7 +6,6 @@
         {{ datatable }}
     {% endblock demo %}
 
-    {% if implementation %}
     <br /><br />
     <h2>Implementation</h2>
     {% block implementation %}
@@ -14,7 +13,6 @@
         {{ implementation|safe }}
         </pre>
     {% endblock implementation %}
-    {% endif %}
 
     <br /><br />
     <h2>Description</h2>

--- a/datatableview/tests/example_project/example_project/example_app/views.py
+++ b/datatableview/tests/example_project/example_project/example_app/views.py
@@ -853,18 +853,17 @@ class HelpersReferenceDatatableView(DemoMixin, XEditableDatatableView):
     implementation = u"""
     class MyDatatable(Datatable):
         class Meta:
-            columns = [
-                ("ID", 'id', helpers.link_to_model),
-                ("Blog", 'blog__name', helpers.link_to_model(key=lambda instance: instance.blog)),
-                ("Headline", 'headline', helpers.make_xeditable),
-                ("Body Text", 'body_text', helpers.itemgetter(slice(0, 30))),
-                ("Publication Date", 'pub_date', helpers.format_date('%A, %b %d, %Y')),
-                ("Modified Date", 'mod_date'),
-                ("Age", 'pub_date', helpers.through_filter(timesince)),
-                ("Interaction", 'get_interaction_total', helpers.make_boolean_checkmark),
-                ("Comments", 'n_comments', helpers.format("{0:,}")),
-                ("Pingbacks", 'n_pingbacks', helpers.format("{0:,}")),
-            ]
+            columns = ['id', 'blog_name', 'headline', 'body_text', 'pub_date', 'mod_date', 'age',
+                       'interaction', 'n_comments', 'n_pingbacks']
+            processors = {
+                'id': helpers.link_to_model,
+                'blog_name': helpers.link_to_model(key=lambda obj: obj.blog),
+                'headline': helpers.make_xeditable,
+                'body_text': helpers.itemgetter(slice(0, 30)),
+                'pub_date': helpers.format_date('%A, %b %d, %Y'),
+                'n_comments': helpers.format("{0:,}"),
+                'n_pingbacks': helpers.format("{0:,}"),
+            }
 
     class HelpersReferenceDatatableView(XEditableDatatableView):
         model = Entry

--- a/datatableview/utils.py
+++ b/datatableview/utils.py
@@ -72,7 +72,12 @@ def resolve_orm_path(model, orm_path):
     if bits[-1] == 'pk':
         field = endpoint_model._meta.pk
     else:
-        field, _, _, _ = endpoint_model._meta.get_field_by_name(bits[-1])
+        # Use the new Model _meta API
+        # https://docs.djangoproject.com/en/1.9/ref/models/meta/
+        if hasattr(endpoint_model._meta, 'get_field_by_name'):
+            field, _, _, _ = endpoint_model._meta.get_field_by_name(bits[-1])
+        else:
+            field = endpoint_model._meta.get_field(bits[-1])
     return field
 
 def get_model_at_related_field(model, attr):
@@ -83,7 +88,13 @@ def get_model_at_related_field(model, attr):
     """
 
     try:
-        field, _, direct, m2m = model._meta.get_field_by_name(attr)
+        # Use the new Model _meta API
+        # https://docs.djangoproject.com/en/1.9/ref/models/meta/
+        if hasattr(model._meta, 'get_field_by_name'):
+            field, _, direct, m2m = model._meta.get_field_by_name(attr)
+        else:
+            field = model._meta.get_field(attr)
+            direct = not field.auto_created
     except FieldDoesNotExist:
         raise
 

--- a/datatableview/utils.py
+++ b/datatableview/utils.py
@@ -129,7 +129,12 @@ def contains_plural_field(model, fields):
         model = source_model
         bits = orm_path.lstrip('+-').split('__')
         for bit in bits[:-1]:
-            field, _, direct, m2m = model._meta.get_field_by_name(bit)
+            # Use the new Model _meta API
+            # https://docs.djangoproject.com/en/1.9/ref/models/meta/
+            if hasattr(model._meta, 'get_field_by_name'):
+                field, _, direct, m2m = model._meta.get_field_by_name(bit)
+            else:
+                field = model._meta.get_field(bit)
             if isinstance(field, models.ManyToManyField) \
                     or (USE_RELATED_OBJECT and isinstance(field, RelatedObject) and field.field.rel.multiple) \
                     or (not USE_RELATED_OBJECT and isinstance(field, RelatedField) and field.one_to_many):

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,7 @@
 from setuptools import setup, find_packages
 
 setup(name='django-datatable-view',
-<<<<<<< HEAD
-<<<<<<< HEAD
       version='0.9.0-beta.5',
-=======
-      version='0.9.0-beta.7',
->>>>>>> 2a49700... Get column value when source is callable
-=======
-      version='0.9.0-beta.6',
->>>>>>> 0a6542e... Lookup types can be passed as arguments to method 'search'
       description='This package is used in conjunction with the jQuery plugin '
                   '(http://http://datatables.net/), and supports state-saving detection'
                   ' with (http://datatables.net/plug-ins/api).  The package consists of '

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,14 @@ from setuptools import setup, find_packages
 
 setup(name='django-datatable-view',
 <<<<<<< HEAD
+<<<<<<< HEAD
       version='0.9.0-beta.5',
 =======
       version='0.9.0-beta.7',
 >>>>>>> 2a49700... Get column value when source is callable
+=======
+      version='0.9.0-beta.6',
+>>>>>>> 0a6542e... Lookup types can be passed as arguments to method 'search'
       description='This package is used in conjunction with the jQuery plugin '
                   '(http://http://datatables.net/), and supports state-saving detection'
                   ' with (http://datatables.net/plug-ins/api).  The package consists of '

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,11 @@
 from setuptools import setup, find_packages
 
 setup(name='django-datatable-view',
+<<<<<<< HEAD
       version='0.9.0-beta.5',
+=======
+      version='0.9.0-beta.7',
+>>>>>>> 2a49700... Get column value when source is callable
       description='This package is used in conjunction with the jQuery plugin '
                   '(http://http://datatables.net/), and supports state-saving detection'
                   ' with (http://datatables.net/plug-ins/api).  The package consists of '


### PR DESCRIPTION
This fixed issue #141 and also adds little extra functionality, as such: if you have multiple boolean columns (most typical example is the users table: is_staff, is_active, is_superuser etc.) searching 'true' will not help much since most columns will have it. Instead you would like to be able to just filter "active" users, or "staff" users.