### PR TITLE
updated option parameters for 1.10

### DIFF
--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -15,7 +15,10 @@ from django.db.models.fields import FieldDoesNotExist
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.encoding import smart_text
 from django.utils.safestring import mark_safe
-from django.forms.util import flatatt
+try:
+    from django.forms.util import flatatt
+except ImportError:
+    from django.forms.utils import flatatt
 from django.template.defaultfilters import slugify
 try:
     from django.utils.encoding import python_2_unicode_compatible

--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -326,7 +326,7 @@ class Column(six.with_metaclass(ColumnMetaclass)):
             lookup_types += ('search',)
         return lookup_types
 
-    def search(self, model, term):
+    def search(self, model, term, lookup_types=None):
         """
         Returns the ``Q`` object representing queries to make against this column for the given
         term.
@@ -356,7 +356,8 @@ class Column(six.with_metaclass(ColumnMetaclass)):
                             k = '%s__exact' % (sub_source,)
                             column_queries.append(Q(**{k: str(db_value)}))
 
-                lookup_types = handler.get_lookup_types()
+                if not lookup_types:
+                    lookup_types = handler.get_lookup_types()
                 for lookup_type in lookup_types:
                     coerced_term = handler.prep_search_value(term, lookup_type)
                     if coerced_term is None:

--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -292,8 +292,8 @@ class Column(six.with_metaclass(ColumnMetaclass)):
             in_bits = re.split(r',\s*', term)
             if len(in_bits) > 1:
                 multi_terms = in_bits
-            else:
-                term = None
+            # else:
+            #     term = None
 
         if lookup_type == "range":
             range_bits = re.split(r'\s*-\s*', term)
@@ -481,10 +481,11 @@ class BooleanColumn(Column):
 
     def prep_search_value(self, term, lookup_type):
         term = term.lower()
-        if term == 'true':
-            term = True
+        # this helps filter users with active status by typing active
+        if term == 'true' or term in self.label.lower():
+            return True
         elif term == 'false':
-            term = False
+            return False
         else:
             return None
         return super(BooleanColumn, self).prep_search_value(term, lookup_type)

--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -208,7 +208,9 @@ class Column(six.with_metaclass(ColumnMetaclass)):
         ``Column`` instances will have sources of their own and need to return a value per nested
         source.
         """
-        if isinstance(obj, Model):
+        if hasattr(source, "__call__"):
+            value = source(obj)
+        elif isinstance(obj, Model):
             value = reduce(get_attribute_value, [obj] + source.split('__'))
         elif isinstance(obj, dict):  # ValuesQuerySet item
             value = obj[source]
@@ -262,6 +264,8 @@ class Column(six.with_metaclass(ColumnMetaclass)):
     def resolve_source(self, model, source):
         # Try to fetch the leaf attribute.  If this fails, the attribute is not database-backed and
         # the search for the first non-database field should end.
+        if hasattr(source, "__call__"):
+            return None
         try:
             return resolve_orm_path(model, source)
         except FieldDoesNotExist:

--- a/datatableview/datatables.py
+++ b/datatableview/datatables.py
@@ -326,8 +326,11 @@ class Datatable(six.with_metaclass(DatatableMetaclass)):
 
             ordering.append('%s%s' % (sort_modifier, column.name))
 
-        if not ordering and config['model']:
-            return config['model']._meta.ordering
+        if not ordering:
+            if self._meta.ordering:
+                return self._meta.ordering
+            if config['model'] and config['model']._meta.ordering:
+                return config['model']._meta.ordering
         return ordering
 
     def resolve_virtual_columns(self, *names):

--- a/datatableview/datatables.py
+++ b/datatableview/datatables.py
@@ -298,27 +298,13 @@ class Datatable(six.with_metaclass(DatatableMetaclass)):
         # For "n" columns (iSortingCols), the queried values iSortCol_0..iSortCol_n are used as
         # column indices to check the values of sSortDir_X and bSortable_X
 
-        default_ordering = config['ordering']
         ordering = []
         columns_list = list(self.columns.values())
 
-        try:
-            num_sorting_columns = int(query_config.get(OPTION_NAME_MAP['num_sorting_columns'], 0))
-        except ValueError:
-            num_sorting_columns = 0
-
-        # Default sorting from view or model definition
-        if num_sorting_columns == 0:
-            return default_ordering
-
-        for sort_queue_i in range(num_sorting_columns):
+        for sort_queue_i in range(len(columns_list)):
             try:
                 column_index = int(query_config.get(OPTION_NAME_MAP['sort_column'] % sort_queue_i, ''))
             except ValueError:
-                continue
-
-            # Reject out-of-range sort requests
-            if column_index >= len(columns_list):
                 continue
 
             column = columns_list[column_index]
@@ -329,7 +315,7 @@ class Datatable(six.with_metaclass(DatatableMetaclass)):
 
             sort_direction = query_config.get(OPTION_NAME_MAP['sort_column_direction'] % sort_queue_i, None)
 
-            sort_modifier = None
+            # sort_modifier = None
             if sort_direction == 'asc':
                 sort_modifier = ''
             elif sort_direction == 'desc':

--- a/datatableview/static/js/datatableview.js
+++ b/datatableview/static/js/datatableview.js
@@ -3,8 +3,8 @@
 var datatableview = {
     auto_initialize: false,
     defaults: {
-        "bServerSide": true,
-        "bPaginate": true
+        "serverSide": true,
+        "paging": true
     },
 
     make_xeditable: function(options) {
@@ -24,7 +24,7 @@ var datatableview = {
                 });
                 return errors.join('\n');
             }
-        }
+        };
         return function(nRow, mData, iDisplayIndex) {
             $('td a[data-xeditable]', nRow).editable(options);
             return nRow;
@@ -55,9 +55,10 @@ var datatableview = {
             };
         }
         var options_name_map = {
-            'config-sortable': 'bSortable',
-            'config-sorting': 'aaSorting',
-            'config-visible': 'bVisible'
+            'config-sortable': 'sortable',
+            'config-sorting': 'order',
+            'config-visible': 'visible',
+            'config-searchable': 'searchable'
         };
 
         var template_clear_button = $('<a href="#" class="clear-search">Clear</a>');
@@ -83,7 +84,7 @@ var datatableview = {
                             value = (value === 'true');
                         }
 
-                        if (name == 'aaSorting') {
+                        if (name == 'order') {
                             // This doesn't go in the column_options
                             var sort_info = value.split(',');
                             sort_info[1] = parseInt(sort_info[1]);
@@ -103,12 +104,14 @@ var datatableview = {
                 sorting_options[i] = sorting_options[i].slice(1);
             }
 
+            // fixme: new name for the sAjaxSource parameter is "ajax" but using that sorting does not work in serverSide mode, either way
+            // querystring sent to the server is same (so is the key:value in local storage), I assume there is a bug in datatables.js 1.10.12
             options = $.extend({}, datatableview.defaults, opts, {
-                "aaSorting": sorting_options,
-                "aoColumns": column_options,
+                "order": sorting_options,
+                "columns": column_options,
                 "sAjaxSource": datatable.attr('data-source-url'),
-                "iDisplayLength": datatable.attr('data-page-length'),
-                "fnInfoCallback": function(oSettings, iStart, iEnd, iMax, iTotal, sPre){
+                "pageLength": datatable.attr('data-page-length'),
+                "infoCallback": function(oSettings, iStart, iEnd, iMax, iTotal, sPre){
                     $("#" + datatable.attr('data-result-counter-id')).html(parseInt(iTotal).toLocaleString());
                     var infoString = oSettings.oLanguage.sInfo.replace('_START_',iStart).replace('_END_',iEnd).replace('_TOTAL_',iTotal);
                     if (iMax != iTotal) {

--- a/datatableview/static/js/datatableview.js
+++ b/datatableview/static/js/datatableview.js
@@ -55,7 +55,8 @@ var datatableview = {
             };
         }
         var options_name_map = {
-            'config-sortable': 'sortable',
+            'name': 'name',
+            'config-sortable': 'orderable',
             'config-sorting': 'order',
             'config-visible': 'visible',
             'config-searchable': 'searchable'
@@ -104,12 +105,10 @@ var datatableview = {
                 sorting_options[i] = sorting_options[i].slice(1);
             }
 
-            // fixme: new name for the sAjaxSource parameter is "ajax" but using that sorting does not work in serverSide mode, either way
-            // querystring sent to the server is same (so is the key:value in local storage), I assume there is a bug in datatables.js 1.10.12
             options = $.extend({}, datatableview.defaults, opts, {
                 "order": sorting_options,
                 "columns": column_options,
-                "sAjaxSource": datatable.attr('data-source-url'),
+                "ajax": datatable.attr('data-source-url'),
                 "pageLength": datatable.attr('data-page-length'),
                 "infoCallback": function(oSettings, iStart, iEnd, iMax, iTotal, sPre){
                     $("#" + datatable.attr('data-result-counter-id')).html(parseInt(iTotal).toLocaleString());

--- a/datatableview/tests/example_project/example_project/example_app/templates/demos/col_reorder.html
+++ b/datatableview/tests/example_project/example_project/example_app/templates/demos/col_reorder.html
@@ -5,8 +5,8 @@
     <script src="{{ STATIC_URL }}syntaxhighlighter/shBrushJScript.js" type="text/javascript"></script>
 
     <!-- Resources for "ColReorder" demo -->
-    <link href="https://cdn.datatables.net/colreorder/1.1.0/css/colReorder.dataTables.min.css" rel="stylesheet"/>
-    <script src="https://cdn.datatables.net/colreorder/1.1.0/js/dataTables.colReorder.min.js"></script>
+    <link href="https://cdn.datatables.net/colreorder/1.3.2/css/colReorder.dataTables.min.css" rel="stylesheet"/>
+    <script src="https://cdn.datatables.net/colreorder/1.3.2/js/dataTables.colReorder.min.js"></script>
 
     <!-- Initialization for ColReorder tables -->
     <script type="text/javascript">

--- a/datatableview/tests/example_project/example_project/example_app/templates/example_base.html
+++ b/datatableview/tests/example_project/example_project/example_app/templates/example_base.html
@@ -6,7 +6,6 @@
         {{ datatable }}
     {% endblock demo %}
 
-    {% if implementation %}
     <br /><br />
     <h2>Implementation</h2>
     {% block implementation %}
@@ -14,7 +13,6 @@
         {{ implementation|safe }}
         </pre>
     {% endblock implementation %}
-    {% endif %}
 
     <br /><br />
     <h2>Description</h2>

--- a/datatableview/tests/example_project/example_project/example_app/views.py
+++ b/datatableview/tests/example_project/example_project/example_app/views.py
@@ -853,18 +853,17 @@ class HelpersReferenceDatatableView(DemoMixin, XEditableDatatableView):
     implementation = u"""
     class MyDatatable(Datatable):
         class Meta:
-            columns = [
-                ("ID", 'id', helpers.link_to_model),
-                ("Blog", 'blog__name', helpers.link_to_model(key=lambda instance: instance.blog)),
-                ("Headline", 'headline', helpers.make_xeditable),
-                ("Body Text", 'body_text', helpers.itemgetter(slice(0, 30))),
-                ("Publication Date", 'pub_date', helpers.format_date('%A, %b %d, %Y')),
-                ("Modified Date", 'mod_date'),
-                ("Age", 'pub_date', helpers.through_filter(timesince)),
-                ("Interaction", 'get_interaction_total', helpers.make_boolean_checkmark),
-                ("Comments", 'n_comments', helpers.format("{0:,}")),
-                ("Pingbacks", 'n_pingbacks', helpers.format("{0:,}")),
-            ]
+            columns = ['id', 'blog_name', 'headline', 'body_text', 'pub_date', 'mod_date', 'age',
+                       'interaction', 'n_comments', 'n_pingbacks']
+            processors = {
+                'id': helpers.link_to_model,
+                'blog_name': helpers.link_to_model(key=lambda obj: obj.blog),
+                'headline': helpers.make_xeditable,
+                'body_text': helpers.itemgetter(slice(0, 30)),
+                'pub_date': helpers.format_date('%A, %b %d, %Y'),
+                'n_comments': helpers.format("{0:,}"),
+                'n_pingbacks': helpers.format("{0:,}"),
+            }
 
     class HelpersReferenceDatatableView(XEditableDatatableView):
         model = Entry

--- a/datatableview/tests/example_project/example_project/example_app/views.py
+++ b/datatableview/tests/example_project/example_project/example_app/views.py
@@ -1180,16 +1180,20 @@ class EmbeddedTableDatatableView(DemoMixin, TemplateView):
             context['datatable'] = SatelliteDatatableView().get_datatable()
             return context
 
-    class MyDatatable(Datatable):
-        class Meta:
-            columns = ['id', 'headline', 'pub_date']
-
     class SatelliteDatatableView(DatatableView):
         \"\"\"
         External view powering the embedded table for ``EmbeddedTableDatatableView``.
         \"\"\"
+        template_name = "blank.html"
         model = Entry
-        datatable_class = MyDatatable
+        class datatable_class(Datatable):
+            class Meta:
+                columns = ['id', 'headline', 'pub_date']
+
+        def get_datatable_kwargs(self):
+            kwargs = super(SatelliteDatatableView, self).get_datatable_kwargs()
+            kwargs['url'] = reverse('satellite')
+            return kwargs
     """
 
 

--- a/datatableview/tests/test_views.py
+++ b/datatableview/tests/test_views.py
@@ -105,11 +105,11 @@ class ViewsTests(DatatableViewTestCase):
         self.assertIn('demo3_datatable', response.context)
 
         demo1_obj = self.get_json_response(str(url) + "?datatable=demo1")
-        self.assertEqual(len(demo1_obj['aaData'][0]), 2 + 2)  # 2 built-in DT items
+        self.assertEqual(len(demo1_obj['data'][0]), 2 + 2)  # 2 built-in DT items
         demo2_obj = self.get_json_response(str(url) + "?datatable=demo2")
-        self.assertEqual(len(demo2_obj['aaData'][0]), 1 + 2)  # 2 built-in DT items
+        self.assertEqual(len(demo2_obj['data'][0]), 1 + 2)  # 2 built-in DT items
         demo3_obj = self.get_json_response(str(url) + "?datatable=demo3")
-        self.assertEqual(len(demo3_obj['aaData'][0]), 3 + 2)  # 2 built-in DT items
+        self.assertEqual(len(demo3_obj['data'][0]), 3 + 2)  # 2 built-in DT items
 
     def test_embedded_table_datatable_view(self):
         view = views.SatelliteDatatableView()

--- a/datatableview/utils.py
+++ b/datatableview/utils.py
@@ -72,7 +72,12 @@ def resolve_orm_path(model, orm_path):
     if bits[-1] == 'pk':
         field = endpoint_model._meta.pk
     else:
-        field, _, _, _ = endpoint_model._meta.get_field_by_name(bits[-1])
+        # Use the new Model _meta API
+        # https://docs.djangoproject.com/en/1.9/ref/models/meta/
+        if hasattr(endpoint_model._meta, 'get_field_by_name'):
+            field, _, _, _ = endpoint_model._meta.get_field_by_name(bits[-1])
+        else:
+            field = endpoint_model._meta.get_field(bits[-1])
     return field
 
 def get_model_at_related_field(model, attr):
@@ -83,7 +88,13 @@ def get_model_at_related_field(model, attr):
     """
 
     try:
-        field, _, direct, m2m = model._meta.get_field_by_name(attr)
+        # Use the new Model _meta API
+        # https://docs.djangoproject.com/en/1.9/ref/models/meta/
+        if hasattr(model._meta, 'get_field_by_name'):
+            field, _, direct, m2m = model._meta.get_field_by_name(attr)
+        else:
+            field = model._meta.get_field(attr)
+            direct = not field.auto_created
     except FieldDoesNotExist:
         raise
 

--- a/datatableview/utils.py
+++ b/datatableview/utils.py
@@ -129,7 +129,12 @@ def contains_plural_field(model, fields):
         model = source_model
         bits = orm_path.lstrip('+-').split('__')
         for bit in bits[:-1]:
-            field, _, direct, m2m = model._meta.get_field_by_name(bit)
+            # Use the new Model _meta API
+            # https://docs.djangoproject.com/en/1.9/ref/models/meta/
+            if hasattr(model._meta, 'get_field_by_name'):
+                field, _, direct, m2m = model._meta.get_field_by_name(bit)
+            else:
+                field = model._meta.get_field(bit)
             if isinstance(field, models.ManyToManyField) \
                     or (USE_RELATED_OBJECT and isinstance(field, RelatedObject) and field.field.rel.multiple) \
                     or (not USE_RELATED_OBJECT and isinstance(field, RelatedField) and field.one_to_many):

--- a/datatableview/utils.py
+++ b/datatableview/utils.py
@@ -22,13 +22,12 @@ DEFAULT_MULTIPLE_SEPARATOR = u" "
 # Since it's rather painful to deal with the datatables.js naming scheme in Python, this map changes
 # the Pythonic names to the javascript ones in the GET request
 OPTION_NAME_MAP = {
-    'start_offset': 'iDisplayStart',
-    'page_length': 'iDisplayLength',
-    'search': 'sSearch',
-    'search_column': 'sSearch_%d',
-    'num_sorting_columns': 'iSortingCols',
-    'sort_column': 'iSortCol_%d',
-    'sort_column_direction': 'sSortDir_%d',
+    'start_offset': 'displayStart',
+    'page_length': 'pageLength',
+    'search': 'search[value]',
+    'search_column': 'columns[%d][search][value]',
+    'sort_column': 'order[%d][column]',
+    'sort_column_direction': 'order[%d][dir]',
 }
 
 # Mapping of Django's supported field types to their more generic type names.

--- a/datatableview/views/base.py
+++ b/datatableview/views/base.py
@@ -42,10 +42,10 @@ class DatatableJSONResponseMixin(object):
         datatable.populate_records()
 
         response_data = {
-            'sEcho': self.request.GET.get('sEcho', None),
-            'iTotalRecords': datatable.total_initial_record_count,
-            'iTotalDisplayRecords': datatable.unpaged_record_count,
-            'aaData': [dict(record, **{
+            'draw': self.request.GET.get('draw', None),
+            'recordsFiltered': datatable.total_initial_record_count,
+            'recordsTotal': datatable.unpaged_record_count,
+            'data': [dict(record, **{
                 'DT_RowId': record.pop('pk'),
                 'DT_RowData': record.pop('_extra_data'),
             }) for record in datatable.get_records()],

--- a/datatableview/views/base.py
+++ b/datatableview/views/base.py
@@ -116,7 +116,7 @@ class DatatableMixin(DatatableJSONResponseMixin, MultipleObjectMixin):
             'model': self.model or queryset.model,
         })
 
-        # This is provided by default, but if the view is instantiated outside of the request cycle
+        # This is, i.e., request, provided by default, but if the view is instantiated outside of the request cycle
         # (such as for the purposes of embedding that view's datatable elsewhere), the request may
         # not be required, so the user may not have a compelling reason to go through the trouble of
         # putting it on self.

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,7 @@
 from setuptools import setup, find_packages
 
 setup(name='django-datatable-view',
-<<<<<<< HEAD
-<<<<<<< HEAD
       version='0.9.0-beta.5',
-=======
-      version='0.9.0-beta.7',
->>>>>>> 2a49700... Get column value when source is callable
-=======
-      version='0.9.0-beta.6',
->>>>>>> 0a6542e... Lookup types can be passed as arguments to method 'search'
       description='This package is used in conjunction with the jQuery plugin '
                   '(http://http://datatables.net/), and supports state-saving detection'
                   ' with (http://datatables.net/plug-ins/api).  The package consists of '

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,14 @@ from setuptools import setup, find_packages
 
 setup(name='django-datatable-view',
 <<<<<<< HEAD
+<<<<<<< HEAD
       version='0.9.0-beta.5',
 =======
       version='0.9.0-beta.7',
 >>>>>>> 2a49700... Get column value when source is callable
+=======
+      version='0.9.0-beta.6',
+>>>>>>> 0a6542e... Lookup types can be passed as arguments to method 'search'
       description='This package is used in conjunction with the jQuery plugin '
                   '(http://http://datatables.net/), and supports state-saving detection'
                   ' with (http://datatables.net/plug-ins/api).  The package consists of '

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,11 @@
 from setuptools import setup, find_packages
 
 setup(name='django-datatable-view',
+<<<<<<< HEAD
       version='0.9.0-beta.5',
+=======
+      version='0.9.0-beta.7',
+>>>>>>> 2a49700... Get column value when source is callable
       description='This package is used in conjunction with the jQuery plugin '
                   '(http://http://datatables.net/), and supports state-saving detection'
                   ' with (http://datatables.net/plug-ins/api).  The package consists of '


### PR DESCRIPTION
Commits f7b2ca6 and 6eb17f6 updates the option parameters to version 1.10 (modern ones). 

There is a kind of test (4 total) that fails.. could not follow through. 