### PR TITLE
Change views.base.serialize_to_json() to use DjangoJSONEncoder

### DIFF
--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -421,7 +421,7 @@ class Column(six.with_metaclass(ColumnMetaclass)):
 
 class TextColumn(Column):
     model_field_class = models.CharField
-    handles_field_classes = [models.CharField, models.TextField, models.FileField]
+    handles_field_classes = [models.CharField, models.TextField, models.FileField, models.UUIDField]
     lookup_types = ('icontains', 'in')
 
 

--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -421,7 +421,14 @@ class Column(six.with_metaclass(ColumnMetaclass)):
 
 class TextColumn(Column):
     model_field_class = models.CharField
-    handles_field_classes = [models.CharField, models.TextField, models.FileField, models.UUIDField]
+    handles_field_classes = [models.CharField, models.TextField, models.FileField]
+
+    # Add UUIDField if present in this version of Django
+    try:
+        handles_field_classes.append(models.UUIDField)
+    except AttributeError:
+        pass
+
     lookup_types = ('icontains', 'in')
 
 

--- a/datatableview/views/base.py
+++ b/datatableview/views/base.py
@@ -7,6 +7,7 @@ from django.views.generic import ListView, TemplateView
 from django.views.generic.list import MultipleObjectMixin
 from django.http import HttpResponse
 from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
 
 from ..datatables import Datatable, DatatableOptions
 
@@ -59,7 +60,9 @@ class DatatableJSONResponseMixin(object):
         if settings.DEBUG:
             indent = 4
 
-        return json.dumps(response_data, indent=indent)
+        # Serialize to JSON with Django's encoder: Adds date/time, decimal,
+        # and UUID support.
+        return json.dumps(response_data, indent=indent, cls=DjangoJSONEncoder)
 
 
 class DatatableMixin(DatatableJSONResponseMixin, MultipleObjectMixin):
@@ -270,5 +273,3 @@ class MultipleDatatableMixin(DatatableJSONResponseMixin):
 
 class MultipleDatatableView(MultipleDatatableMixin, TemplateView):
     pass
-
-


### PR DESCRIPTION
Resolves a JSON serialization exception when using UUIDs for primary keys.  This should also allow handling of any other additional types Django adds to their custom JSON serializer in the future.