### PR TITLE
Update imports to remove Django 1.8 LTS deprecation warning

### DIFF
--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -16,9 +16,9 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.utils.encoding import smart_text
 from django.utils.safestring import mark_safe
 try:
-    from django.forms.util import flatatt
-except ImportError:
     from django.forms.utils import flatatt
+except ImportError:
+    from django.forms.util import flatatt
 from django.template.defaultfilters import slugify
 try:
     from django.utils.encoding import python_2_unicode_compatible


### PR DESCRIPTION
In Django 1.8 LTS, the following depreciation warning gets thrown:

```
/opt/venv/myproject/src/django-datatable-view/datatableview/columns.py:19: RemovedInDjango19Warning: The django.forms.util module has been renamed. Use django.forms.utils instead.
  from django.forms.util import flatatt
```

Switching the order of the try/catch block fixes it.

Warning: I haven't tested this in more recent versions of Django, but I can't see how it couldn't work.