### PR TITLE
Fix datatable field mapping

### DIFF
--- a/datatableview/utils.py
+++ b/datatableview/utils.py
@@ -24,8 +24,8 @@ DEFAULT_MULTIPLE_SEPARATOR = u" "
 # Since it's rather painful to deal with the datatables.js naming scheme in Python, this map changes
 # the Pythonic names to the javascript ones in the GET request
 OPTION_NAME_MAP = {
-    'start_offset': 'displayStart',
-    'page_length': 'pageLength',
+    'start_offset': 'start',
+    'page_length': 'length',
     'search': 'search[value]',
     'search_column': 'columns[%d][search][value]',
     'sort_column': 'order[%d][column]',


### PR DESCRIPTION
With the current mapping, it is not possible to change pages or change the number of rows per page. See https://datatables.net/manual/server-side for more information about the parameters sent from datatables.js.

This pull request fixes this issue.