### PR TITLE
Fixed unreferenced local variable in Datatable pagination

### DIFF
--- a/datatableview/datatables.py
+++ b/datatableview/datatables.py
@@ -393,8 +393,10 @@ class Datatable(six.with_metaclass(DatatableMetaclass)):
             i_begin = self.config['start_offset']
             i_end = self.config['start_offset'] + self.config['page_length']
             object_list = self._records[i_begin:i_end]
+        else:
+            object_list = self._records
 
-        return self._records
+        return object_list
 
     def get_records(self):
         """

--- a/datatableview/datatables.py
+++ b/datatableview/datatables.py
@@ -394,7 +394,7 @@ class Datatable(six.with_metaclass(DatatableMetaclass)):
             i_end = self.config['start_offset'] + self.config['page_length']
             object_list = self._records[i_begin:i_end]
 
-        return object_list
+        return self._records
 
     def get_records(self):
         """


### PR DESCRIPTION
Hi,

I got an UnboundLocalVariableError while using this pull request https://github.com/pivotal-energy-solutions/django-datatable-view/issues/148, because paginations weren't working.
Even if you don't plan on merging the aforementioned pull request, I think this is a import fix that could avoid things breaking in the future.

Thanks for your work !
Cheers,
Victor