### PR TITLE
fix typecast out of string

### DIFF
--- a/datatableview/datatables.py
+++ b/datatableview/datatables.py
@@ -37,7 +37,7 @@ def pretty_name(name):
     return name[0].capitalize() + name[1:]
 
 
-# Borrowed from the Django forms implementation 
+# Borrowed from the Django forms implementation
 def columns_for_model(model, fields=None, exclude=None, labels=None, processors=None,
                       unsortable=None, hidden=None):
     field_list = []
@@ -81,7 +81,7 @@ def columns_for_model(model, fields=None, exclude=None, labels=None, processors=
         )
     return field_dict
 
-# Borrowed from the Django forms implementation 
+# Borrowed from the Django forms implementation
 def get_declared_columns(bases, attrs, with_base_columns=True):
     """
     Create a list of form field instances from the passed in 'attrs', plus any
@@ -668,7 +668,7 @@ class Datatable(six.with_metaclass(DatatableMetaclass)):
             q = reduce(operator.and_, table_queries)
             queryset = queryset.filter(q)
 
-        return queryset
+        return queryset.distinct()
 
     def _search_column(self, column, terms):
         """ Requests search queries to be performed against the target column.  """

--- a/datatableview/static/js/datatableview.js
+++ b/datatableview/static/js/datatableview.js
@@ -44,7 +44,7 @@ var datatableview = (function(){
 
                     // Typecasting out of string
                     name = optionsNameMap[name];
-                    if (/^b/.test(name)) {
+                    if (/^(true|false)/.test(value.toLowerCase())) {
                         value = (value === 'true');
                     }
 


### PR DESCRIPTION
Problem
---------
Altering visible and sortable on column definitions was not having any effect on my datatables table. It turns out visible and sortable were being kept as strings and not correctly parsed.

What this fixes
--------------
```python
class ExampleDatatable(Datatable):
    cost_average = columns.FloatColumn(sources=['cost_average_at_transfer'], visible=True)
    quantity_requested = columns.IntegerColumn(sources=['quantity_requested'], sortable=False)

     # ...
```

What this doesn't fix
---------------------

```python
class ExampleDatatable(Datatable):

    class Meta:
        model = ExampleModel
        columns = ['cost_average', 'quantity_requested']
        hidden_columns = ['quantity_requested',]
       # ...
```

Not overly familiar with this codebase yet but so far this has been effective. I'm using the latest version of Datatables.