### PR TITLE
show correct num_filtered if filtering by individual columns

### DIFF
--- a/datatableview/datatables.py
+++ b/datatableview/datatables.py
@@ -650,7 +650,7 @@ class Datatable(six.with_metaclass(DatatableMetaclass)):
         else:
             num_total = len(base_objects)
 
-        if len(self.config['search']) > 0:
+        if len(self.config['search']) > 0 or len(self.config['column_searches']) > 0:
             if isinstance(filtered_objects, QuerySet):
                 num_filtered = filtered_objects.count()
             else:


### PR DESCRIPTION
When filtering/searching by individual columns, the number of found (num_filtered) records was not being returned.

This checks to see if there are any column search criteria and returns the correct number of filtered records so that it can be displayed at the bottom of a datatable.