### PR TITLE
fix: initialization script

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Use the ``{{ datatable }}`` provided in the template context to render the table
 <script type="text/javascript" charset="utf8" src="{% static 'js/datatableview.js' %}"></script>
 <script type="text/javascript">
     $(function(){
-        datatableview.initialize('.datatable');
+        datatableview.initialize($('.datatable'));
     });
 </script>
 


### PR DESCRIPTION
```
 datatableview.initialize('.datatable');
```
throws a jquery error and does not initialize the table 

```
datatableview.initialize($('.datatable'));
```
does not, and renders the table completely