### PR TITLE
Select plugin support column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ db.sqlite3
 appengine
 docs/_build
 .idea
+.venv/

--- a/datatableview/__init__.py
+++ b/datatableview/__init__.py
@@ -2,7 +2,7 @@
 
 from .datatables import Datatable, ValuesDatatable, LegacyDatatable
 from .columns import (Column, TextColumn, DateColumn, DateTimeColumn, BooleanColumn, IntegerColumn,
-                      FloatColumn, DisplayColumn, CompoundColumn)
+                      FloatColumn, DisplayColumn, CompoundColumn, CheckBoxSelectColumn)
 from .exceptions import SkipRecord
 
 __name__ = 'datatableview'

--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -588,3 +588,29 @@ class DisplayColumn(Column):
 
     model_field_class = None
     lookup_types = ()
+
+
+class CheckBoxSelectColumn(DisplayColumn):
+    """
+    Renders a column of checkboxes with Select all items checkbox on the top
+    Example here: https://datatables.net/extensions/select/examples/initialisation/checkbox.html
+    """
+
+    def __init__(self, label='Select all', show_select_checkbox=True, *args, **kwargs):
+        if show_select_checkbox:
+            label += """
+                <input
+                data-id='all'
+                type='checkbox'
+                onchange="
+                if ($(this).is(':checked')) {
+                $(this).closest('table').DataTable().rows().select();
+                } else {
+                $(this).closest('table').DataTable().rows().deselect();
+                }
+                ">
+                """
+        super(CheckBoxSelectColumn, self).__init__(label=label, *args, **kwargs)
+
+    def value(self, obj, **kwargs):
+        return ''

--- a/datatableview/tests/example_project/example_project/example_app/templates/base.html
+++ b/datatableview/tests/example_project/example_project/example_app/templates/base.html
@@ -97,6 +97,7 @@
                     <li class="nav-list-item dropdown-header">Extension support</li>
                     <li class="nav-list-item"><a href="{% url "col-reorder" %}">ColReorder</a></li>
                     <li class="nav-list-item"><a href="{% url "multi-filter" %}">Per-column search</a></li>
+                    <li class="nav-list-item"><a href="{% url "select-row" %}">Select row</a></li>
                     <li class="divider"></li>
                     <li class="nav-list-item dropdown-header">Template rendering</li>
                     <li class="nav-list-item"><a href="{% url "js-init" %}">Javascript initialization</a></li>

--- a/datatableview/tests/example_project/example_project/example_app/templates/demos/select_row.html
+++ b/datatableview/tests/example_project/example_project/example_app/templates/demos/select_row.html
@@ -1,0 +1,90 @@
+{% extends "example_base.html" %}
+
+{% block static %}
+    {{ block.super }}
+    <script src="{{ STATIC_URL }}syntaxhighlighter/shBrushJScript.js" type="text/javascript"></script>
+
+    <!-- Resources for "Select row" demo -->
+    <script type="text/javascript" src="https://cdn.datatables.net/select/1.3.1/js/dataTables.select.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/select/1.3.1/css/select.dataTables.min.css">
+
+    <style type="text/css">
+    .datatable th.select-checkbox {
+        width: 8%;
+    }
+    </style>
+
+    <!-- Initialization for ColReorder tables -->
+    <script type="text/javascript">
+        datatableview.finalizeOptions = (function(){
+            var super_finalizeOptions = datatableview.finalizeOptions;
+
+            return function _confirm_datatable_options(datatable, options){
+                /**
+                 * Search our chechbox column by `data-idall` and add select plugin options to our checkboxes
+                 * Also we need to set class 'select-checkbox' for our <td> element.
+                 */
+                if (options['columns'] &&
+                    options['columns'].length) {
+                    for (var i=0; i<options['columns'].length; i++) {
+                        if (options['columns'][i]['name'] &&
+                            options['columns'][i]['name'].indexOf('data-idall') !== -1) {
+                            options.select = {
+                                style: 'multi',
+                                selector: 'td:first-child'
+                            };
+                            options['columns'][i]['sClass'] = 'select-checkbox'
+                        }
+                    }
+                }
+                options = super_finalizeOptions(datatable, options);
+                return options
+            }
+        })();
+    </script>
+{% endblock static %}
+
+
+{% block implementation %}
+<pre class="brush: javascript">
+    datatableview.finalizeOptions = (function(){
+            var super_finalizeOptions = datatableview.finalizeOptions;
+            return function _confirm_datatable_options(datatable, options){
+                /**
+                 * Search our chechbox column by `data-idall` and add select plugin options to our checkboxes
+                 * Also we need to set class 'select-checkbox' for our <td> element.
+                 */
+                if (options['columns'] &&
+                    options['columns'].length) {
+                    for (var i=0; i < options['columns'].length; i++) {
+
+                        if (options['columns'][i]['name'] &&
+                            options['columns'][i]['name'].indexOf('data-idall') !== -1) {
+                            options.select = {
+                                style: 'multi',
+                                selector: 'td:first-child'
+                            };
+
+                            options['columns'][i]['sClass'] = 'select-checkbox'
+                        }
+                    }
+                }
+                options = super_finalizeOptions(datatable, options);
+                return options
+            }
+        })();
+
+
+    /*
+        For example to get selected rows use:
+    */
+        var datatable = document.querySelector('#DataTables_Table_0')[0].DataTable();
+        var selecteditems = [];
+        datatable.on('select', function (e, dt, type, indexes) {
+                selecteditems = dt.rows({selected: true}).ids().toArray();
+            }).on( 'deselect', function ( e, dt, type, indexes ) {
+                selecteditems = dt.rows({selected: true}).ids().toArray();
+            });
+
+</pre>
+{% endblock implementation %}

--- a/datatableview/tests/example_project/example_project/example_app/views.py
+++ b/datatableview/tests/example_project/example_project/example_app/views.py
@@ -3,7 +3,7 @@
 from os import sep
 import os.path
 import re
-
+import django
 from django.urls import reverse
 from django.views.generic import View, TemplateView
 from django.template.defaultfilters import timesince
@@ -1335,6 +1335,28 @@ class MultiFilterDatatableView(DemoMixin, DatatableView):
         class Meta:
             columns = ['headline', 'blog']
             footer = True
+
+    implementation = u"""dummy"""  # don't hide the block, overridden in template
+
+
+class SelectRowDatatableView(DemoMixin, DatatableView):
+    """
+    The official <a href="https://datatables.net/extensions/select/">``Select``
+    extension</a> is easy to add to any existing table.  To use it, make sure you include the
+    appropriate javascript source file, and add to config following options
+    ```{
+        style: 'multi',
+        selector: 'td:first-child'
+    }```
+    """
+    model = Entry
+
+    class datatable_class(Datatable):
+        select_data = columns.CheckBoxSelectColumn()
+        blog = columns.TextColumn("Blog", sources=['blog__name'])
+
+        class Meta:
+            columns = ['select_data', 'headline', 'blog']
 
     implementation = u"""dummy"""  # don't hide the block, overridden in template
 


### PR DESCRIPTION
Add `CheckBoxSelectColumn` and examples for support official [Select](https://datatables.net/extensions/select/ ) plugin 

![Screen Shot 2019-10-28 at 14 12 34](https://user-images.githubusercontent.com/3278913/67677555-028cd600-f98d-11e9-86b2-173dbaccfefe.png)


https://datatables.net/extensions/select/examples/initialisation/checkbox.html