### PR TITLE
Search fields and field lookup bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ appengine
 docs/_build
 .idea
 .venv/
+venv

--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -494,14 +494,20 @@ class BooleanColumn(Column):
     lookup_types = ('exact', 'in')
 
     def prep_search_value(self, term, lookup_type):
-        term = term.lower()
+        try:
+            term = term.lower()
+            label = self.label.lower()
+        except AttributeError:
+            label = ""
+
         # Allow column's own label to represent a true value
-        if term == 'true' or term.lower() in self.label.lower():
+        if term in ['True', 'true'] or term in label:
             term = True
-        elif term == 'false':
+        elif term in ['False', 'false']:
             term = False
         else:
             return None
+
         return super(BooleanColumn, self).prep_search_value(term, lookup_type)
 
 

--- a/datatableview/columns.py
+++ b/datatableview/columns.py
@@ -496,6 +496,11 @@ class BooleanColumn(Column):
     def prep_search_value(self, term, lookup_type):
         try:
             term = term.lower()
+        except AttributeError:
+            pass
+
+        # In some cases self.label is None
+        try:
             label = self.label.lower()
         except AttributeError:
             label = ""

--- a/datatableview/datatables.py
+++ b/datatableview/datatables.py
@@ -681,7 +681,7 @@ class Datatable(six.with_metaclass(DatatableMetaclass)):
         for term in self.config['search']:
             # NOTE: Allow global terms to overwrite identical queries that were single-column
             searches[term] = self.columns.copy()
-            searches[term].update({None: column for column in self.config['search_fields']})
+            searches[term].update({column.sources[0]: column for column in self.config['search_fields']})
 
         for term in searches.keys():
             term_queries = []


### PR DESCRIPTION
Hi tiliv

First of all, thank you for sharing this great plugin with us! We used it in an integration poc and found the following two bugs - this PR fixes them:

- #213: search_fields option on Meta ignoring items except the last one
- lookup on BooleanColumn causes 500 server error when self.label is None

Best regards
Remo