### PR TITLE
mark use of hashlib.sha1() for cache keys appropriately, re-enable related bandit warnings

### DIFF
--- a/datatableview/cache.py
+++ b/datatableview/cache.py
@@ -48,7 +48,7 @@ if CACHE_KEY_HASH:
 
 
 def _hash_key_component(s):
-    return hashlib.sha1(s.encode("utf-8")).hexdigest()[hash_slice]
+    return hashlib.sha1(s.encode("utf-8"), usedforsecurity=False).hexdigest()[hash_slice]
 
 
 def get_cache_key(datatable_class, view=None, user=None, **kwargs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ line-ending = "auto"
 [tool.bandit]
 targets = ['datatableview', "demo_app"]
 exclude_dirs = ["datatableview/tests"]
-skips = ["B303", "B308", "B323", "B324", "B703"]
+skips = ["B308", "B323", "B703"]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ line-ending = "auto"
 [tool.bandit]
 targets = ['datatableview', "demo_app"]
 exclude_dirs = ["datatableview/tests"]
-skips = ["B308", "B323", "B703"]
+skips = ["B308", "B703"]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Hey there! I noticed some of the `bandit` tests were disabled in pyproject.toml, and took a look. Please see commit descriptions for the explanations.